### PR TITLE
segregation can be installed from CRAN

### DIFF
--- a/08-modeling-census-data.Rmd
+++ b/08-modeling-census-data.Rmd
@@ -23,7 +23,7 @@ Much of the segregation and diversity literature focuses on race and ethnicity, 
 ```{r get-race-data-ch8}
 library(tidycensus)
 library(tidyverse)
-library(segregation) # remotes::install_github("elbersb/segregation")
+library(segregation)
 library(tigris)
 library(sf)
 


### PR DESCRIPTION
I've just submitted a new version of segregation to CRAN, and the code in the book runs without problems using this version, so `remotes::install_github` is no longer necessary